### PR TITLE
Fixed issue with TraceableEventDispatcher instance in ContainerAwareEventDispatcher::__construct()

### DIFF
--- a/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -5,8 +5,7 @@ namespace Jmikola\WildcardEventDispatcherBundle\EventDispatcher;
 use Jmikola\WildcardEventDispatcher\WildcardEventDispatcher;
 use Jmikola\WildcardEventDispatcher\LazyListenerPattern;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher as BaseContainerAwareEventDispatcher;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContainerAwareEventDispatcher extends WildcardEventDispatcher
 {
@@ -17,9 +16,9 @@ class ContainerAwareEventDispatcher extends WildcardEventDispatcher
      * Constructor.
      *
      * @param ContainerInterface                $container
-     * @param BaseContainerAwareEventDispatcher dispatcher
+     * @param EventDispatcherInterface          $dispatcher
      */
-    public function __construct(ContainerInterface $container, BaseContainerAwareEventDispatcher $dispatcher)
+    public function __construct(ContainerInterface $container, EventDispatcherInterface $dispatcher)
     {
         parent::__construct($dispatcher);
 


### PR DESCRIPTION
Catchable Fatal Error: Argument 2 passed to Jmikola\WildcardEventDispatcherBundle\EventDispatcher\ContainerAwareEventDispatcher::__construct() must be an instance of Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher, instance of Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher given

Symfony2 version: 2.5.0
