### PR TITLE
Symfony 3.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,31 @@
 language: php
 
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache
+
 php:
   - 5.3
   - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
-before_script: composer install --dev
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: hhvm
+        - env: SYMFONY_VERSION=3.0.*
+
+    include:
+        - php: 5.3
+          env: COMPOSER_FLAGS="--prefer-lowest"
+
+before_install:
+    - travis_retry composer self-update
+
+install:
+    - composer update ${COMPOSER_FLAGS} --no-interaction

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Build Status](https://travis-ci.org/jmikola/JmikolaWildcardEventDispatcherBundle.png?branch=master)](https://travis-ci.org/jmikola/JmikolaWildcardEventDispatcherBundle)
 
-This bundle integrates the [WildcardEventDispatcher][] library with Symfony2 and
+This bundle integrates the [WildcardEventDispatcher][] library with Symfony and
 allows event listeners to be assigned using a wildcard pattern inspired by
 AMQP topic exchanges.
 
-Symfony2's event dispatcher component and the framework's existing convention
+Symfony's event dispatcher component and the framework's existing convention
 for event names (dot-separated words) is already quite similar to AMQP message
 routing keys. This bundle is intended to be used sparingly, where wildcards may
 replace verbose configuration for central listeners, such as an activity logging
@@ -24,7 +24,7 @@ This bundle requires Symfony 2.3 or above.
 
 ## Configuration
 
-There are no configuration options. Symfony2 will load the bundle's dependency
+There are no configuration options. Symfony will load the bundle's dependency
 injection extension automatically.
 
 The extension will create a service that [composes][] the existing

--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ mailing list.
 
 ## Compatibility
 
-This bundle's `master` branch maintains compatibility with Symfony2's master
-branch. The 1.0.x tag for this bundle tracks its `master` branch.
-
-There is no support for Symfony 2.0.x.
+This bundle requires Symfony 2.3 or above.
 
 ## Configuration
 

--- a/Tests/Functional/app/config.yml
+++ b/Tests/Functional/app/config.yml
@@ -2,7 +2,7 @@ services:
     count_listener:
         class: Jmikola\WildcardEventDispatcherBundle\Tests\Functional\CountListener
         tags:
-            - { name: kernel.event_listener, event: *.request, method: onEvent }
+            - { name: kernel.event_listener, event: "*.request", method: onEvent }
 
 framework:
     secret: foobar

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "authors": [
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
     ],
-    "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
         "jmikola/wildcard-event-dispatcher": "1.0.*",

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
     },
     "autoload": {
         "psr-4": { "Jmikola\\WildcardEventDispatcherBundle\\": "" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "jmikola/wildcard-event-dispatcher": "1.0.*",
-        "symfony/config": "~2.1",
-        "symfony/dependency-injection": "~2.1",
-        "symfony/event-dispatcher": "~2.1",
-        "symfony/http-kernel": "~2.1"
+        "jmikola/wildcard-event-dispatcher": "^1.1.0",
+        "symfony/config": "^2.3 || ^3.0",
+        "symfony/dependency-injection": "^2.3 || ^3.0",
+        "symfony/event-dispatcher": "^2.3 || ^3.0",
+        "symfony/http-kernel": "^2.3 || ^3.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "~2.1",
-        "symfony/class-loader": "~2.1",
-        "symfony/framework-bundle": "~2.1",
-        "symfony/yaml": "~2.1"
+        "symfony/browser-kit": "^2.3 || ^3.0",
+        "symfony/class-loader": "^2.3 || ^3.0",
+        "symfony/framework-bundle": "^2.3 || ^3.0",
+        "symfony/yaml": "^2.3 || ^3.0"
     },
     "autoload": {
         "psr-4": { "Jmikola\\WildcardEventDispatcherBundle\\": "" }


### PR DESCRIPTION
Depends on WildcardEventDispatcher 1.1.0, which includes https://github.com/jmikola/WildcardEventDispatcher/pull/7.

Allows compatibility with Symfony 3.0 and raises the minimum requirement to Symfony 2.3. 