### PR TITLE
[WIP] Compatibility with Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,29 @@
 language: php
-
+dist: trusty
 sudo: false
 
-cache:
-    directories:
-        - $HOME/.composer/cache
-
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
+
+cache:
+  directories:
+    - ${HOME}/.composer/cache/files
 
 matrix:
-    fast_finish: true
-    allow_failures:
-        - php: hhvm
+  fast_finish: true
+  include:
+    - php: 5.3
+      dist: precise
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
-    include:
-        - php: 5.3
-          env: COMPOSER_FLAGS="--prefer-lowest"
+before_script:
+  - phpenv config-rm xdebug.ini
+  - composer update --no-interaction --no-progress --no-suggest ${COMPOSER_FLAGS}
 
-before_install:
-    - travis_retry composer self-update
-
-install:
-    - composer update ${COMPOSER_FLAGS} --no-interaction
+script:
+  - vendor/bin/phpunit -v

--- a/Tests/DependencyInjection/Compiler/ReplaceEventDispatcherPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ReplaceEventDispatcherPassTest.php
@@ -3,10 +3,11 @@
 namespace Jmikola\WildcardEventDispatcherBundle\Tests\DependencyInjection\Compiler;
 
 use Jmikola\WildcardEventDispatcherBundle\DependencyInjection\Compiler\ReplaceEventDispatcherPass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class ReplaceEventDispatcherPassTest extends \PHPUnit_Framework_TestCase
+class ReplaceEventDispatcherPassTest extends TestCase
 {
     private $container;
     private $pass;

--- a/Tests/DependencyInjection/Compiler/SetInnerEventDispatcherPassTest.php
+++ b/Tests/DependencyInjection/Compiler/SetInnerEventDispatcherPassTest.php
@@ -3,10 +3,11 @@
 namespace Jmikola\WildcardEventDispatcherBundle\Tests\DependencyInjection\Compiler;
 
 use Jmikola\WildcardEventDispatcherBundle\DependencyInjection\Compiler\SetInnerEventDispatcherPass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class SetInnerEventDispatcherPassTest extends \PHPUnit_Framework_TestCase
+class SetInnerEventDispatcherPassTest extends TestCase
 {
     private $container;
     private $pass;

--- a/Tests/DependencyInjection/JmikolaWildcardEventDispatcherExtensionTest.php
+++ b/Tests/DependencyInjection/JmikolaWildcardEventDispatcherExtensionTest.php
@@ -3,9 +3,10 @@
 namespace Jmikola\WildcardEventDispatcherBundle\Tests\DependencyInjection;
 
 use Jmikola\WildcardEventDispatcherBundle\DependencyInjection\JmikolaWildcardEventDispatcherExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class JmikolaWildcardEventDispatcherExtensionTest extends \PHPUnit_Framework_TestCase
+class JmikolaWildcardEventDispatcherExtensionTest extends TestCase
 {
     public function testShouldLoadServiceDefinition()
     {

--- a/Tests/EventDispatcher/ContainerAwareEventDispatcherTest.php
+++ b/Tests/EventDispatcher/ContainerAwareEventDispatcherTest.php
@@ -3,11 +3,12 @@
 namespace Jmikola\WildcardEventDispatcherBundle\Tests\Functional;
 
 use Jmikola\WildcardEventDispatcherBundle\EventDispatcher\ContainerAwareEventDispatcher;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher as SymfonyContainerAwareEventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
 
-class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class ContainerAwareEventDispatcherTest extends TestCase
 {
     const coreRequest = 'core.request';
     const coreException = 'core.exception';

--- a/Tests/JmikolaWildcardEventDispatcherBundleTest.php
+++ b/Tests/JmikolaWildcardEventDispatcherBundleTest.php
@@ -3,9 +3,10 @@
 namespace Jmikola\WildcardEventDispatcherBundle\Tests;
 
 use Jmikola\WildcardEventDispatcherBundle\JmikolaWildcardEventDispatcherBundle;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class JmikolaWildcardEventDispatcherBundleTest extends \PHPUnit_Framework_TestCase
+class JmikolaWildcardEventDispatcherBundleTest extends TestCase
 {
     public function testShouldAddCompilerPass()
     {

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     "require": {
         "php": ">=5.3.2",
         "jmikola/wildcard-event-dispatcher": "^1.1.0",
-        "symfony/config": "^2.3 || ^3.0",
-        "symfony/dependency-injection": "^2.3 || ^3.0",
-        "symfony/event-dispatcher": "^2.3 || ^3.0",
-        "symfony/http-kernel": "^2.3 || ^3.0"
+        "symfony/config": "^2.3 || ^3.0 || ^4.0",
+        "symfony/dependency-injection": "^2.3 || ^3.0 || ^4.0",
+        "symfony/event-dispatcher": "^2.3 || ^3.0 || ^4.0",
+        "symfony/http-kernel": "^2.3 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "^2.3 || ^3.0",
-        "symfony/class-loader": "^2.3 || ^3.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0",
-        "symfony/yaml": "^2.3 || ^3.0"
+        "symfony/browser-kit": "^2.3 || ^3.0 || ^4.0",
+        "symfony/class-loader": "^2.3 || ^3.0 || ^4.0",
+        "symfony/framework-bundle": "^2.3 || ^3.0 || ^4.0",
+        "symfony/yaml": "^2.3 || ^3.0 || ^4.0"
     },
     "autoload": {
         "psr-4": { "Jmikola\\WildcardEventDispatcherBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "symfony/http-kernel": "^2.3 || ^3.0 || ^4.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.8.36 || ^6.4",
         "symfony/browser-kit": "^2.3 || ^3.0 || ^4.0",
         "symfony/class-loader": "^2.3 || ^3.0 || ^4.0",
         "symfony/framework-bundle": "^2.3 || ^3.0 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jmikola/wildcard-event-dispatcher-bundle",
     "type": "symfony-bundle",
-    "description": "Enhances the Symfony2 event dispatcher with support for wildcard patterns inspired by AMQP topic exchanges.",
+    "description": "Enhances the Symfony event dispatcher with support for wildcard patterns inspired by AMQP topic exchanges.",
     "keywords": ["AMQP", "dispatcher", "event", "event dispatcher"],
     "homepage": "https://github.com/jmikola/JmikolaWildcardEventDispatcherBundle",
     "license": "MIT",


### PR DESCRIPTION
Related to https://github.com/jmikola/WildcardEventDispatcher/pull/11.

Note: Symfony 4.0 removed the ContainerAwareEventDispatcher in https://github.com/symfony/symfony/pull/20937, so this will need some additional work. https://github.com/sonata-project/SonataNotificationBundle/pull/248 and https://github.com/symfony/symfony/issues/22402 may help provide some guidance.